### PR TITLE
Add SERVICE_NAME env var to check for correct .env file

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, user_prod]
 
     env:
+      SERVICE_NAME: ${{ vars.SERVICE_NAME }}
       DB_SERVER_DEV: ${{ secrets.DB_SERVER_PROD }}
       DB_DATABASE_DEV: ${{ secrets.DB_DATABASE_DEV }}
       DB_DATABASE_PORT: ${{ secrets.DB_DATABASE_PORT }}
@@ -56,6 +57,7 @@ jobs:
 
       - name: Create .env file from GitHub Secrets
         run: |
+          echo "SERVICE_NAME=${{ vars.SERVICE_NAME }}" >> .env      # Taken from GitHub Actions Variables
           echo "DB_SERVER_DEV=${{ secrets.DB_SERVER_PROD }}" >> .env
           echo "DB_DATABASE_DEV=${{ secrets.DB_DATABASE_DEV }}" >> .env
           echo "DB_DATABASE_PORT=${{ secrets.DB_DATABASE_PORT }}" >> .env

--- a/.github/workflows/cd‑staging.yml
+++ b/.github/workflows/cd‑staging.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, user]
 
     env:
+      SERVICE_NAME: ${{ vars.SERVICE_NAME }}
       DB_SERVER_DEV: ${{ secrets.DB_SERVER_STG }}
       DB_DATABASE_DEV: ${{ secrets.DB_DATABASE_DEV }}
       DB_DATABASE_PORT: ${{ secrets.DB_DATABASE_PORT }}
@@ -56,6 +57,7 @@ jobs:
 
       - name: Create .env file from GitHub Secrets
         run: |
+          echo "SERVICE_NAME=${{ vars.SERVICE_NAME }}" >> .env      # Taken from GitHub Actions Variables
           echo "DB_SERVER_DEV=${{ secrets.DB_SERVER_STG }}" >> .env
           echo "DB_DATABASE_DEV=${{ secrets.DB_DATABASE_DEV }}" >> .env
           echo "DB_DATABASE_PORT=${{ secrets.DB_DATABASE_PORT }}" >> .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
+      SERVICE_NAME: ${{ vars.SERVICE_NAME }}
       DB_SERVER_DEV: ${{ secrets.DB_SERVER_STG }}
       DB_DATABASE_DEV: ${{ secrets.DB_DATABASE_DEV }}
       DB_DATABASE_PORT: ${{ secrets.DB_DATABASE_PORT }}
@@ -38,6 +39,7 @@ jobs:
 
       - name: Create .env file from GitHub Secrets
         run: |
+          echo "SERVICE_NAME=${{ vars.SERVICE_NAME }}" >> .env      # Taken from GitHub Actions Variables
           echo "DB_SERVER_DEV=${{ secrets.DB_SERVER_STG }}" >> .env
           echo "DB_DATABASE_DEV=${{ secrets.DB_DATABASE_DEV }}" >> .env
           echo "DB_DATABASE_PORT=${{ secrets.DB_DATABASE_PORT }}" >> .env

--- a/app/database.py
+++ b/app/database.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import sqlalchemy as sa
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base
@@ -7,17 +8,31 @@ from dotenv import load_dotenv
 
 # Load environment variables from .env file
 load_dotenv()
-# Get the database URL from environment variables
-DB_URL_LOCAL = os.getenv("DB_URL_LOCAL")
-DB_DRIVER_DEV = os.getenv("DB_DRIVER_DEV")
-DB_SERVER_DEV = os.getenv("DB_SERVER_DEV")
-DB_DATABASE_DEV = os.getenv("DB_DATABASE_DEV")
-DB_DATABASE_PORT = os.getenv("DB_DATABASE_PORT")
-DB_USERNAME_DEV = os.getenv("DB_USERNAME_DEV")
-DB_PASSWORD_DEV = os.getenv("DB_PASSWORD_DEV")
+
+SERVICE_NAME = os.getenv("SERVICE_NAME")
+if SERVICE_NAME != "PATIENT":
+    print("Please ensure you are using the correct .env file for PATIENT service!")
+    sys.exit(1)
+
+#====  DB Connection Config ===
+def get_env_var(name, required=True, service=None):
+    value = os.getenv(name)
+    if required and not value:
+        print(f"{name} environment variable is not set.")
+        sys.exit(1)
+    return value
+
+# Get the database URL from environment variables (required to connect to server's DB)
+DB_DRIVER_DEV = get_env_var("DB_DRIVER_DEV")
+DB_SERVER_DEV = get_env_var("DB_SERVER_DEV")
+DB_DATABASE_DEV = get_env_var("DB_DATABASE_DEV")
+DB_DATABASE_PORT = get_env_var("DB_DATABASE_PORT")
+DB_USERNAME_DEV = get_env_var("DB_USERNAME_DEV")
+DB_PASSWORD_DEV = get_env_var("DB_PASSWORD_DEV")
+
 
 # Get the database URL from environment (DOCKER LOCAL)
-#DB_URL_LOCAL = os.getenv("DB_URL_LOCAL")
+DB_URL_LOCAL = os.getenv("DB_URL_LOCAL")
 DB_DRIVER = os.getenv("DB_DRIVER")
 DB_SERVER = os.getenv("DB_SERVER")
 DB_DATABASE = os.getenv("DB_DATABASE")

--- a/app/database.py
+++ b/app/database.py
@@ -10,8 +10,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 SERVICE_NAME = os.getenv("SERVICE_NAME")
-if SERVICE_NAME != "PATIENT":
-    print("Please ensure you are using the correct .env file for PATIENT service!")
+if SERVICE_NAME != "USER":
+    print("Please ensure you are using the correct .env file for USER service!")
     sys.exit(1)
 
 #====  DB Connection Config ===


### PR DESCRIPTION
- Added SERVICE_NAME to GitHub actions Variables instead of Secret.
- Updated Confluence with the new .env


Idea is just to add a simple env var in the Confluence .env, so hopefully even if the dev is using the old (dont have this new SERVICE_NAME) or using a another set of .env for another service, the SERVICE_NAME will not be "USER" for this user service.