### PR TITLE
add service auth for get_active_staff endpoint

### DIFF
--- a/app/routers/supervisor_router.py
+++ b/app/routers/supervisor_router.py
@@ -1,5 +1,5 @@
 from app.utils.utils import mask_nric
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Header
 from sqlalchemy.orm import Session
 from ..database import get_db
 from ..crud import user_crud as crud_user 
@@ -9,9 +9,11 @@ from ..schemas import account as schemas_account
 from ..schemas import user_auth
 from ..service import email_service as EmailService
 from ..service import user_auth_service as AuthService 
+from ..service.service_auth import verify_service_api_key, get_optional_current_user
 from app.models.user_model import User
 import logging
 import sys
+import os
 from typing import Optional
 
 
@@ -46,11 +48,17 @@ def get_doctor_by_name(userId: str, current_user: user_auth.TokenData = Depends(
 
 @router.get("/supervisor/get_active_staff", response_model=schemas_user.UserRoleListResponse)
 @rate_limit(global_bucket, tokens_required=1)
-def get_active_staff(current_user: user_auth.TokenData = Depends(AuthService.get_current_user),db: Session = Depends(get_db)):
-    is_supervisor = current_user["roleName"] == "SUPERVISOR"
+def get_active_staff(
+    db: Session = Depends(get_db),
+    current_user: Optional[dict] = Depends(get_optional_current_user),
+    x_api_key: Optional[str] = Header(None, alias="X-Api-Key"),
+):
+    is_supervisor = current_user and current_user.get("roleName") == "SUPERVISOR"
+    is_service = x_api_key and x_api_key == os.environ.get("INTERNAL_SERVICE_API_KEY")
 
-    if not is_supervisor:
-        raise HTTPException(status_code=404, detail="User is not authorised")
+    if not is_supervisor and not is_service:
+        raise HTTPException(status_code=403, detail="Not authorised")
+
     role_whitelist = ["DOCTOR", "SUPERVISOR", "GAME THERAPIST", "CAREGIVER"]
     db_users=db.query(User).filter((User.roleName.in_(role_whitelist))&(User.isDeleted==False)).all()
     result = []

--- a/app/service/service_auth.py
+++ b/app/service/service_auth.py
@@ -1,0 +1,29 @@
+import os
+from typing import Optional
+from fastapi import Header, HTTPException, status, Depends
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+from ..database import get_db
+
+_optional_oauth2 = OAuth2PasswordBearer(tokenUrl="/api/v1/login", auto_error=False)
+
+
+def get_optional_current_user(
+    token: Optional[str] = Depends(_optional_oauth2),
+    db: Session = Depends(get_db),
+) -> Optional[dict]:
+    if not token:
+        return None
+    from ..service import user_auth_service as AuthService
+    try:
+        return AuthService.get_current_user(token=token, db=db)
+    except HTTPException:
+        return None
+
+
+def verify_service_api_key(x_api_key: str = Header(..., alias="X-Api-Key")) -> None:
+    service_key = os.environ.get("INTERNAL_SERVICE_API_KEY")
+    if not service_key:
+        raise HTTPException(status_code=500, detail="Service API key not configured.")
+    if x_api_key != service_key:
+        raise HTTPException(status_code=403, detail="Invalid service API key.")


### PR DESCRIPTION
added service_auth.py to handle inter-service calls to get_active_staff. endpoint now accepts either a supervisor jwt or an internal api key via X-Api-Key header. key is loaded from env.